### PR TITLE
Fix OPENSSL error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2567,6 +2567,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.0+3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2574,6 +2583,7 @@ checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib", "rlib"]
 path="src/lib.rs"
 
 [dependencies]
-openssl = "0.10.72"
+openssl = { version="0.10.72", features = ["vendored"] }
 ring = "0.17.12"
 
 eyre = { version = "0.6.12" }


### PR DESCRIPTION
Fix error locating OPENSSL library in pytest on certain OS. https://github.com/sfackler/rust-openssl/issues/2400